### PR TITLE
fixed logo overlapping to content in mobile view  resolve (#95)

### DIFF
--- a/css/custom.css
+++ b/css/custom.css
@@ -98,3 +98,10 @@
   margin-top: 2px;
   margin-bottom: 2px;
 }
+
+@media screen and (min-width: 280px) and (max-width: 653px) {
+.icon.pe-7s-map-marker {
+  margin-bottom: 10px;
+}
+
+}


### PR DESCRIPTION
### added margin bottom to fixed the overlapping of logo with the content ...............

### screenshot before 
![2015 issue](https://user-images.githubusercontent.com/65535360/89547770-cba0f600-d823-11ea-9b38-15bcd1d96a4b.PNG)

### screenshot after 
![2015 fposs](https://user-images.githubusercontent.com/65535360/89547788-d2c80400-d823-11ea-912c-24b4a344cd18.PNG)
 
#95  fixed 
@mariobehling @liveHarshit 